### PR TITLE
FEAT: add child accounts to aws org

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ No requirements.
 | <a name="input_organization_id"></a> [organization\_id](#input\_organization\_id) | AWS Organization ID | `string` | n/a | yes |
 | <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | n/a | `string` | n/a | yes |
 | <a name="input_service_access_principals"></a> [service\_access\_principals](#input\_service\_access\_principals) | List of AWS Service Access Principals that you want to enable for organization integration | `list(string)` | <pre>[<br/>  "cloudtrail.amazonaws.com",<br/>  "config.amazonaws.com",<br/>  "config-multiaccountsetup.amazonaws.com",<br/>  "member.org.stacksets.cloudformation.amazonaws.com",<br/>  "sso.amazonaws.com",<br/>  "ssm.amazonaws.com",<br/>  "servicecatalog.amazonaws.com",<br/>  "guardduty.amazonaws.com",<br/>  "controltower.amazonaws.com",<br/>  "securityhub.amazonaws.com",<br/>  "ram.amazonaws.com",<br/>  "tagpolicies.tag.amazonaws.com"<br/>]</pre> | no |
+| <a name="input_child_accounts"></a> [child\_accounts](#input\_child\_accounts) | The AWS accounts that should be added to the organization | `list(string)` | null | no |
 
 ## Outputs
 

--- a/org.tf
+++ b/org.tf
@@ -6,6 +6,13 @@ resource "aws_organizations_organization" "org" {
   enabled_policy_types = var.enabled_policy_types
 }
 
+resource "null_resource" "add_org_account" {
+  count = var.child_accounts == null ? 0 : length(var.child_accounts)
+  provisioner "local-exec" {
+    command = "aws organizations invite-account-to-organization --target '{\"Type\": \"ACCOUNT\", \"Id\": \"${var.child_accounts[count.index]}\"}' & sleep 10"
+  }
+}
+
 # resource "aws_organizations_delegated_administrator" "delegated_admin" {
 #   for_each = toset(var.delegated_admin_account_id)
 

--- a/variables.tf
+++ b/variables.tf
@@ -71,6 +71,12 @@ variable "enabled_policy_types" {
   default     = [""]
 }
 
+variable "child_accounts" {
+  description = "AWS Account IDs you want to add to the organization"
+  type = list(string)
+  default = null
+}
+
 # variable "delegated_admin_account_id" {
 #   description = "The account ID number of the member account in the organization to register as a delegated administrator."
 #   type        = list(string)


### PR DESCRIPTION
This is a semi automated way to invite child accounts to an AWS org. From my research there is no way to programmatically accept the invites for each child account in the org, so unfortunately this might be a moot point to add, and feel free to close this PR if it's not adding value.

As a high level, this just uses a local-exec provisioner to use aws CLI to invite an org. This assumes you have AWS CLI installed on your machine, and uses whatever local AWS profile you have set in your terminal. I added a sleep 10 to the command since local execs run in parallel, and the AWS CLI is modifying the same resource, so it will throw an error if you don't wait for each account to be added individually. This is a little janky since it's using local exec, but this is probably the most simple way to do this effectively with account numbers instead of account email addresses.